### PR TITLE
TSLint with prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Purpose
 
-This package contains a set of tslint rules that enforces a consistent code style in all Typescript projects.
+This package contains a set of TSLint rules that enforces a consistent code style in all TypeScript projects.
 
 # Usage
 
 Install using npm to your devDependencies:
 
 ```
-npm install --save-dev https://github.com/insurello/tslint-insurello
+npm install --save-dev insurello/tslint-insurello#2.0.0
 ```
 
-Configure tslint to use `tslint-insurello` by adding it to your `tslint.json`:
+Configure TSLint to use `tslint-insurello` by adding it to your `tslint.json`:
 
 ```javascript
 {

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ Configure tslint to use `tslint-insurello` by adding it to your `tslint.json`:
    }
 }
 ```
+
+Default serverity level is warning, to force error set the enviroment variable `CI`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,14 @@
 {
   "name": "tslint-insurello",
   "version": "1.0.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "tslint-config-prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
+      "dev": true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-insurello",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Code style rules for tslint.",
   "main": "tslint-insurello.json",
   "repository": {
@@ -10,8 +10,8 @@
   "keywords": [
     "tslint"
   ],
-  "author": "Niklas Holmgren",
-  "license": "ISC",
+  "author": "Insurello AB",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/insurello/tslint-insurello/issues"
   },

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/insurello/tslint-insurello/issues"
   },
-  "homepage": "https://github.com/insurello/tslint-insurello#readme"
+  "homepage": "https://github.com/insurello/tslint-insurello#readme",
+  "devDependencies": {
+    "tslint-config-prettier": "^1.18.0"
+  }
 }

--- a/tslint-insurello.json
+++ b/tslint-insurello.json
@@ -1,18 +1,3 @@
 {
-  "extends": ["tslint:latest", "tslint-config-prettier"],
-  "defaultSeverity": "warning",
-  "rules": {
-    "interface-name": [true, "never-prefix"],
-    "interface-over-type-literal": false,
-    "object-literal-sort-keys": false,
-    "variable-name": {
-      "options": [
-        "ban-keywords",
-        "check-format",
-        "allow-leading-underscore",
-        "allow-pascal-case"
-      ]
-    },
-    "no-var-requires": false
-  }
+  "extends": "./tslint.config"
 }

--- a/tslint-insurello.json
+++ b/tslint-insurello.json
@@ -1,54 +1,18 @@
 {
-    "extends": [
-        "tslint:recommended"
-    ],
-    "defaultSeverity": "error",
-    "rules": {
-      "arrow-parens": false,
-      "max-file-line-count": [true, 300],
-      "max-line-length": [true, 80],
-      "cyclomatic-complexity": [true, 20],
-      "max-classes-per-file": [true, 1],
-      "indent": [true, "spaces", 2],
-      "eofline": true,
-      "encoding": true,
-      "linebreak-style": [true, "LF"],
-      "trailing-comma": [
-        true,
-        {
-          "multiline": {
-            "objects": "never",
-            "arrays": "never",
-            "functions": "never",
-            "typeLiterals": "never"
-          }
-        }
-      ],
-      "import-spacing": true,
-      "no-consecutive-blank-lines": [true, 2],
-      "no-irregular-whitespace": true,
-      "no-trailing-whitespace": true,
-      "semicolon": {
-        "options": [
-          "always",
-          "ignore-interfaces",
-          "ignore-bound-class-methods"
-        ]
-      },
-      "variable-name": {
-        "options": [
-            "ban-keywords",
-            "check-format",
-            "allow-leading-underscore",
-            "allow-pascal-case"
-        ]
-      },
-      "object-literal-key-quotes": [true, "as-needed"],
-      "interface-name": [true, "never-prefix"],
-
-
-      "only-arrow-functions": false,
-      "object-literal-sort-keys": false,
-      "no-var-requires": false
-    }
+  "extends": ["tslint:latest", "tslint-config-prettier"],
+  "defaultSeverity": "warning",
+  "rules": {
+    "interface-name": [true, "never-prefix"],
+    "interface-over-type-literal": false,
+    "object-literal-sort-keys": false,
+    "variable-name": {
+      "options": [
+        "ban-keywords",
+        "check-format",
+        "allow-leading-underscore",
+        "allow-pascal-case"
+      ]
+    },
+    "no-var-requires": false
+  }
 }

--- a/tslint.config.js
+++ b/tslint.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  extends: ["tslint:latest", "tslint-config-prettier"],
+  defaultSeverity: process.env.CI ? "error" : "warning",
+  rules: {
+    "interface-name": [true, "never-prefix"],
+    "interface-over-type-literal": false,
+    "object-literal-sort-keys": false,
+    "variable-name": {
+      options: [
+        "ban-keywords",
+        "check-format",
+        "allow-leading-underscore",
+        "allow-pascal-case"
+      ]
+    },
+    "no-var-requires": false
+  }
+};


### PR DESCRIPTION
### Problem
* TSLint and prettier have conflicting rules
* TSLint has severity error but should be warning in development

### Solution
Disable all formatting configs that prettier will handle for us. Only use severity error when environment variable `CI` is set