### PR TITLE
Disable max classes per file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package contains a set of TSLint rules that enforces a consistent code styl
 Install using npm to your devDependencies:
 
 ```
-npm install --save-dev insurello/tslint-insurello#2.0.0
+npm install --save-dev insurello/tslint-insurello#2.0.1
 ```
 
 Configure TSLint to use `tslint-insurello` by adding it to your `tslint.json`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-insurello",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Code style rules for TSLint",
   "main": "tslint-insurello.json",
   "repository": {

--- a/tslint.config.js
+++ b/tslint.config.js
@@ -13,6 +13,7 @@ module.exports = {
         "allow-pascal-case"
       ]
     },
-    "no-var-requires": false
+    "no-var-requires": false,
+    "max-classes-per-file": false
   }
 };


### PR DESCRIPTION
### Problem
One file doesn't equal single responsibility making the rational for the rule `max-classes-per-file` irrelevant.

### Solution
Disable the rule `max-classes-per-file`

Co-authored-by: Axel Olsson <axel.olsson@insurello.se>