### PR TITLE
Include devDependencies as explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package contains a set of TSLint rules that enforces a consistent code styl
 Install using npm to your devDependencies:
 
 ```
-npm install --save-dev insurello/tslint-insurello#2.0.1
+npm install --save-dev insurello/tslint-insurello#v2.0.2
 ```
 
 Configure TSLint to use `tslint-insurello` by adding it to your `tslint.json`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-insurello",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-insurello",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Code style rules for TSLint",
   "main": "tslint-insurello.json",
   "repository": {

--- a/tslint.config.js
+++ b/tslint.config.js
@@ -14,6 +14,7 @@ module.exports = {
       ]
     },
     "no-var-requires": false,
-    "max-classes-per-file": false
+    "max-classes-per-file": false,
+    "no-implicit-dependencies": [true, "dev"]
   }
 };


### PR DESCRIPTION
### Problem

TSLint does not consider devDependencies as explicit leading to a lot of warnings in test files.

### Solution

Make devDependencies explicit to TSLint.