### PR TITLE
Blacklist import of fp-ts trace to prevent merging debug logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package contains a set of TSLint rules that enforces a consistent code styl
 Install using npm to your devDependencies:
 
 ```
-npm install --save-dev insurello/tslint-insurello#v2.0.4
+npm install --save-dev insurello/tslint-insurello#v2.0.5
 ```
 
 Configure TSLint to use `tslint-insurello` by adding it to your `tslint.json`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-insurello",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Code style rules for TSLint",
   "main": "tslint-insurello.json",
   "repository": {

--- a/tslint.config.js
+++ b/tslint.config.js
@@ -16,6 +16,7 @@ module.exports = {
     "no-var-requires": false,
     "max-classes-per-file": false,
     "no-implicit-dependencies": [true, "dev"],
-    "no-submodule-imports": [true, "fp-ts", "io-ts"]
+    "no-submodule-imports": [true, "fp-ts", "io-ts"],
+    "import-blacklist": [true, "fp-ts/lib/Trace", { "fp-ts": ["trace"] }]
   }
 };


### PR DESCRIPTION
### Problem

Using `trace` from `fp-ts` may lead to merging code that logs unwanted data in production.

### Solution

Blacklist import of `trace` so on usage we get error on CI builds.