### PR TITLE
Remove no-submodule-imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package contains a set of TSLint rules that enforces a consistent code styl
 Install using npm to your devDependencies:
 
 ```
-npm install --save-dev insurello/tslint-insurello#v2.1.0
+npm install --save-dev insurello/tslint-insurello#v2.2.0
 ```
 
 Configure TSLint to use `tslint-insurello` by adding it to your `tslint.json`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-insurello",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Code style rules for TSLint",
   "main": "tslint-insurello.json",
   "scripts": {

--- a/tslint.config.js
+++ b/tslint.config.js
@@ -11,7 +11,7 @@ module.exports = {
     "interface-over-type-literal": false,
     "max-classes-per-file": false,
     "no-implicit-dependencies": [true, "dev"],
-    "no-submodule-imports": [true, "fp-ts", "io-ts", "io-ts-types"],
+    "no-submodule-imports": false,
     "no-var-requires": false,
     "object-literal-sort-keys": false,
     "variable-name": {


### PR DESCRIPTION
### Problem
We often need to use `// tslint:disable-next-line: no-submodule-imports` comments because many libraries have submodule imports as part of their public API.

### Solution
Remove the rule. We don’t have a problem with people importing random private submodules, so this rule only annoys us.

(The rule is part of `tslint:latest`, so it had to be turned off rather than just removed from our config.)